### PR TITLE
Issue with multiple entities inheriting from a base type

### DIFF
--- a/src/Impatient/Query/ExpressionVisitors/Composing/NavigationComposingExpressionVisitor.cs
+++ b/src/Impatient/Query/ExpressionVisitors/Composing/NavigationComposingExpressionVisitor.cs
@@ -2209,7 +2209,7 @@ namespace Impatient.Query.ExpressionVisitors.Composing
 
             protected override Expression VisitMember(MemberExpression node)
             {
-                var descriptor = descriptors.SingleOrDefault(d => d.Member == node.Member);
+                var descriptor = descriptors.SingleOrDefault(d => d.Type == node.Type && d.Member == node.Member);
 
                 if (descriptor == null)
                 {


### PR DESCRIPTION
When 2 entity objects inherit 1 base object which contains a navigation property, the `SingleOrDefault()` call in `NavigationFindingExpressionVisitor` finds many matches.
The fix also searches the descriptor type in addition to the descriptor's member.