### PR TITLE
Change projects to target Standard 2.0.

### DIFF
--- a/src/Impatient.EntityFrameworkCore.SqlServer/ExpressionVisitors/EFCoreQueryableInliningExpressionVisitor.cs
+++ b/src/Impatient.EntityFrameworkCore.SqlServer/ExpressionVisitors/EFCoreQueryableInliningExpressionVisitor.cs
@@ -38,14 +38,12 @@ namespace Impatient.EntityFrameworkCore.SqlServer
             {
                 var key = queryable.ElementType.TypeHandle.Value;
 
-                var query
-                    = modelQueryExpressionCache.Lookup.GetOrAdd(
-                        key,
-                        (k, arg) => 
-                            arg.modelExpressionProvider.CreateQueryExpression(
-                                arg.queryable.ElementType,
-                                arg.currentDbContext.Context),
-                        (modelExpressionProvider, queryable, currentDbContext));
+                if (!modelQueryExpressionCache.Lookup.ContainsKey(key))
+                {
+                    modelQueryExpressionCache.Lookup.TryAdd(key, modelExpressionProvider.CreateQueryExpression(queryable.ElementType, currentDbContext.Context));
+                }
+
+                modelQueryExpressionCache.Lookup.TryGetValue(key, out Expression query);
 
                 // This block is moreso for types with defining queries than types that
                 // just happen to have query filters. The defining queries need to be inlined.

--- a/src/Impatient.EntityFrameworkCore.SqlServer/Impatient.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Impatient.EntityFrameworkCore.SqlServer/Impatient.EntityFrameworkCore.SqlServer.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <VersionPrefix>2.1.2</VersionPrefix>
     <Authors>tuespetre</Authors>
@@ -15,11 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Impatient/Impatient.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
+    <ProjectReference Include="..\Impatient\Impatient.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Impatient/Extensions/ImpatientExtensions.cs
+++ b/src/Impatient/Extensions/ImpatientExtensions.cs
@@ -8,26 +8,6 @@ namespace Impatient.Extensions
     {
         #region Naive implementations of Enumerable operators from .NET Core 2.0
 
-        public static IEnumerable<TSource> Append<TSource>(this IEnumerable<TSource> source, TSource element)
-        {
-            foreach (var item in source)
-            {
-                yield return item;
-            }
-
-            yield return element;
-        }
-
-        public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource element)
-        {
-            yield return element;
-
-            foreach (var item in source)
-            {
-                yield return item;
-            }
-        }
-
         public static IEnumerable<TSource> SkipLast<TSource>(this IEnumerable<TSource> source, int count)
         {
             return source.Reverse().Skip(count).Reverse();
@@ -38,7 +18,7 @@ namespace Impatient.Extensions
             return source.Reverse().Take(count).Reverse();
         }
 
-        #endregion
+        #endregion Naive implementations of Enumerable operators from .NET Core 2.0
 
         public static IOrderedQueryable<TSource> AsOrderedQueryable<TSource>(this IQueryable<TSource> source)
         {

--- a/src/Impatient/Impatient.csproj
+++ b/src/Impatient/Impatient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   

--- a/src/Impatient/Query/ExpressionVisitors/Composing/NavigationComposingExpressionVisitor.cs
+++ b/src/Impatient/Query/ExpressionVisitors/Composing/NavigationComposingExpressionVisitor.cs
@@ -56,7 +56,7 @@ namespace Impatient.Query.ExpressionVisitors.Composing
             public override Expression Visit(Expression node)
             {
                 var visited = base.Visit(node);
-                
+
                 if (!(node is null || visited is null)
                     && node.Type.IsGenericType(typeof(IOrderedQueryable<>))
                     && !visited.Type.IsGenericType(typeof(IOrderedQueryable<>)))
@@ -86,24 +86,24 @@ namespace Impatient.Query.ExpressionVisitors.Composing
                 {
                     // Uncertain
                     case nameof(Queryable.Aggregate):
-                    {
-                        break;
-                    }
+                        {
+                            break;
+                        }
 
                     case nameof(Enumerable.ToDictionary):
                     case nameof(Enumerable.ToLookup):
-                    {
-                        // TODO: Handle ToDictionary
-                        // TODO: Handle ToLookup
-                        break;
-                    }
+                        {
+                            // TODO: Handle ToDictionary
+                            // TODO: Handle ToLookup
+                            break;
+                        }
 
                     // These will need more consideration
                     case nameof(Queryable.Cast):
                     case nameof(Queryable.OfType):
-                    {
-                        break;
-                    }
+                        {
+                            break;
+                        }
 
                     // Pass-through methods (just need a generic type change)
                     case nameof(Enumerable.AsEnumerable):
@@ -111,70 +111,70 @@ namespace Impatient.Query.ExpressionVisitors.Composing
                     case nameof(Queryable.Reverse):
                     case nameof(Queryable.Skip):
                     case nameof(Queryable.Take):
-                    //case nameof(Queryable.SkipLast):
-                    //case nameof(Queryable.TakeLast):
-                    {
-                        return HandlePassthroughMethod(node);
-                    }
+                        //case nameof(Queryable.SkipLast):
+                        //case nameof(Queryable.TakeLast):
+                        {
+                            return HandlePassthroughMethod(node);
+                        }
 
                     // Complex selector lambdas
 
                     case nameof(Queryable.Select):
-                    {
-                        return HandleSelect(node);
-                    }
+                        {
+                            return HandleSelect(node);
+                        }
 
                     case nameof(Queryable.SelectMany):
-                    {
-                        return HandleSelectMany(node);
-                    }
+                        {
+                            return HandleSelectMany(node);
+                        }
 
                     case nameof(Queryable.GroupBy):
-                    {
-                        return HandleGroupBy(node);
-                    }
+                        {
+                            return HandleGroupBy(node);
+                        }
 
                     case nameof(Queryable.GroupJoin):
-                    {
-                        return HandleGroupJoin(node);
-                    }
+                        {
+                            return HandleGroupJoin(node);
+                        }
 
                     case nameof(Queryable.Join):
-                    {
-                        return HandleJoin(node);
-                    }
+                        {
+                            return HandleJoin(node);
+                        }
 
                     case nameof(Queryable.Zip):
-                    {
-                        return HandleZip(node);
-                    }
+                        {
+                            return HandleZip(node);
+                        }
 
                     // Intermediate selector lambdas
                     case nameof(Queryable.OrderBy):
                     case nameof(Queryable.OrderByDescending):
                     case nameof(Queryable.ThenBy):
                     case nameof(Queryable.ThenByDescending):
-                    {
-                        return HandleOrderByMethod(node);
-                    }
+                        {
+                            return HandleOrderByMethod(node);
+                        }
 
                     // Terminal selector lambdas
                     case nameof(Queryable.Average) when node.Arguments.Count == 2:
                     case nameof(Queryable.Max) when node.Arguments.Count == 2:
                     case nameof(Queryable.Min) when node.Arguments.Count == 2:
                     case nameof(Queryable.Sum) when node.Arguments.Count == 2:
-                    {
-                        return HandleTerminalSelectorMethod(node);
-                    }
+                        {
+                            return HandleTerminalSelectorMethod(node);
+                        }
 
                     // Type-independent terminal predicate lambdas
                     case nameof(Queryable.All):
                     case nameof(Queryable.Any) when node.Arguments.Count == 2:
                     case nameof(Queryable.Count) when node.Arguments.Count == 2:
                     case nameof(Queryable.LongCount) when node.Arguments.Count == 2:
-                    {
-                        return HandleTypeIndependentTerminalPredicateMethod(node);
-                    }
+                        {
+                            return HandleTypeIndependentTerminalPredicateMethod(node);
+                        }
 
                     // Type-dependent terminal predicate lambdas
                     case nameof(Queryable.First) when node.Arguments.Count == 2:
@@ -183,17 +183,17 @@ namespace Impatient.Query.ExpressionVisitors.Composing
                     case nameof(Queryable.LastOrDefault) when node.Arguments.Count == 2:
                     case nameof(Queryable.Single) when node.Arguments.Count == 2:
                     case nameof(Queryable.SingleOrDefault) when node.Arguments.Count == 2:
-                    {
-                        return HandleTypeDependentTerminalPredicateMethod(node);
-                    }
+                        {
+                            return HandleTypeDependentTerminalPredicateMethod(node);
+                        }
 
                     // Non-terminal predicate lambdas
                     case nameof(Queryable.SkipWhile):
                     case nameof(Queryable.TakeWhile):
                     case nameof(Queryable.Where):
-                    {
-                        return HandleNonTerminalPredicateMethod(node);
-                    }
+                        {
+                            return HandleNonTerminalPredicateMethod(node);
+                        }
                 }
 
                 return base.VisitMethodCall(node);
@@ -1416,21 +1416,21 @@ namespace Impatient.Query.ExpressionVisitors.Composing
                 switch (node)
                 {
                     case NavigationExpansionContextExpression nece:
-                    {
-                        return Visit(nece.Result);
-                    }
+                        {
+                            return Visit(nece.Result);
+                        }
 
                     default:
-                    {
-                        return base.Visit(node);
-                    }
+                        {
+                            return base.Visit(node);
+                        }
                 }
             }
         }
 
         /// <summary>
         /// This expression represents a subtree that is currently being expanded by the navigation
-        /// rewriting expression visitor. 
+        /// rewriting expression visitor.
         /// </summary>
         private sealed class NavigationExpansionContextExpression : Expression
         {
@@ -1622,7 +1622,7 @@ namespace Impatient.Query.ExpressionVisitors.Composing
             }
 
             /// <summary>
-            /// Finds expandable navigations stemming from the given <paramref name="parameter"/> 
+            /// Finds expandable navigations stemming from the given <paramref name="parameter"/>
             /// within the given <paramref name="lambda"/> then builds upon the given <paramref name="source"/>
             /// while advancing the context's 'current parameter' and recording mappings from the
             /// navigation paths to the new paths that can be used to access those values in the <paramref name="source"/>.
@@ -1930,10 +1930,10 @@ namespace Impatient.Query.ExpressionVisitors.Composing
                     Parameter = context.currentParameter,
                 });
 
-                var expander 
+                var expander
                     = new NavigationExpandingExpressionVisitor(
-                        parameter, 
-                        context.currentParameter, 
+                        parameter,
+                        context.currentParameter,
                         context.mappings);
 
                 var resultSelectorBody = expander.Visit(selector.Body);
@@ -2265,19 +2265,19 @@ namespace Impatient.Query.ExpressionVisitors.Composing
                 switch (node)
                 {
                     case ExtendedNewExpression extendedNewExpression:
-                    {
-                        return VisitExtendedNew(extendedNewExpression);
-                    }
+                        {
+                            return VisitExtendedNew(extendedNewExpression);
+                        }
 
                     case ExtendedMemberInitExpression extendedMemberInitExpression:
-                    {
-                        return VisitExtendedMemberInit(extendedMemberInitExpression);
-                    }
+                        {
+                            return VisitExtendedMemberInit(extendedMemberInitExpression);
+                        }
 
                     default:
-                    {
-                        return base.VisitExtension(node);
-                    }
+                        {
+                            return base.VisitExtension(node);
+                        }
                 }
             }
 
@@ -2434,41 +2434,41 @@ namespace Impatient.Query.ExpressionVisitors.Composing
                 switch (node)
                 {
                     case MemberExpression memberExpression:
-                    {
-                        var descriptor = descriptors.SingleOrDefault(d => d.Member == memberExpression.Member);
-
-                        if (descriptor != null)
                         {
-                            UnwindMemberExpression(memberExpression, out var expression, out var path);
+                            var descriptor = descriptors.SingleOrDefault(d => d.Member == memberExpression.Member);
 
-                            if (expression is ParameterExpression parameterExpression)
+                            if (descriptor != null)
                             {
-                                Mappings.Add(
-                                    new MemberPathMapping(
-                                        parameterExpression,
-                                        path,
-                                        CurrentPath.ToList()));
+                                UnwindMemberExpression(memberExpression, out var expression, out var path);
+
+                                if (expression is ParameterExpression parameterExpression)
+                                {
+                                    Mappings.Add(
+                                        new MemberPathMapping(
+                                            parameterExpression,
+                                            path,
+                                            CurrentPath.ToList()));
+                                }
                             }
+
+                            return node;
                         }
 
-                        return node;
-                    }
-
                     case ParameterExpression parameterExpression:
-                    {
-                        Mappings.Add(
-                            new MemberPathMapping(
-                                parameterExpression,
-                                new List<MemberInfo>(),
-                                CurrentPath.ToList()));
+                        {
+                            Mappings.Add(
+                                new MemberPathMapping(
+                                    parameterExpression,
+                                    new List<MemberInfo>(),
+                                    CurrentPath.ToList()));
 
-                        return node;
-                    }
+                            return node;
+                        }
 
                     default:
-                    {
-                        return node;
-                    }
+                        {
+                            return node;
+                        }
                 }
             }
         }

--- a/test/Impatient.EFCore.Tests/Impatient.EFCore.Tests.csproj
+++ b/test/Impatient.EFCore.Tests/Impatient.EFCore.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/Impatient.Tests/Impatient.Tests.csproj
+++ b/test/Impatient.Tests/Impatient.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />


### PR DESCRIPTION
I was looking for iqueriable project and found this, but my projects all target standard 2.0, only final projects using dotnet core in target.
Then I change target of all core projects to standard 2.0 with a few refacory, also I update version of SqlServer nuget to last release vesion.
After convert the projects I run all tests and more tests is passing now. I dont make changes in tests.